### PR TITLE
Packaged mlspp in vendored and made vcpkg toggleable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "vendor/qrcodegen"]
 	path = vendor/qrcodegen
 	url = https://github.com/nayuki/QR-Code-generator.git
-[submodule "vendor/vendor/mlspp"]
-	path = vendor/vendor/mlspp
-	url = https://github.com/cisco/mlspp.git
 [submodule "vendor/mlspp"]
 	path = vendor/mlspp
 	url = https://github.com/cisco/mlspp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "vendor/vendor/mlspp"]
 	path = vendor/vendor/mlspp
 	url = https://github.com/cisco/mlspp.git
+[submodule "vendor/mlspp"]
+	path = vendor/mlspp
+	url = https://github.com/cisco/mlspp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "vendor/qrcodegen"]
 	path = vendor/qrcodegen
 	url = https://github.com/nayuki/QR-Code-generator.git
+[submodule "vendor/vendor/mlspp"]
+	path = vendor/vendor/mlspp
+	url = https://github.com/cisco/mlspp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
-option(USE_VCPKG "Use vcpkg-provided dependencies" ON)
 
 if(ENABLE_VOICE)
     if(USE_VCPKG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 
-# vcpkg toolchain must be set before project() so find_package is intercepted.
-# Allow override via -DCMAKE_TOOLCHAIN_FILE for users who manage vcpkg externally.
-if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/vcpkg/scripts/buildsystems/vcpkg.cmake"
+option(USE_VCPKG "Use bundled vcpkg toolchain" ON)
+
+# Must happen before project()
+if(USE_VCPKG AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE
+        "${CMAKE_CURRENT_SOURCE_DIR}/vendor/vcpkg/scripts/buildsystems/vcpkg.cmake"
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
@@ -18,15 +20,31 @@ set(CMAKE_AUTORCC ON)
 
 option(BUILD_TESTS "Build test targets" ON)
 option(ENABLE_VOICE "Build with voice/audio support" ON)
+
 if(BUILD_TESTS)
     enable_testing()
 endif()
 
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
+option(USE_VCPKG "Use vcpkg-provided dependencies" ON)
+
 if(ENABLE_VOICE)
-    find_package(unofficial-sodium CONFIG REQUIRED)
-    find_package(Opus CONFIG REQUIRED)
+    if(USE_VCPKG)
+        find_package(unofficial-sodium CONFIG REQUIRED)
+        find_package(Opus CONFIG REQUIRED)
+
+	set(SODIUM_TARGET unofficial-sodium::sodium)
+        set(OPUS_TARGET Opus::opus)
+    else()
+        find_package(PkgConfig REQUIRED)
+
+	pkg_check_modules(SODIUM REQUIRED IMPORTED_TARGET libsodium)
+	pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
+
+	set(SODIUM_TARGET PkgConfig::SODIUM)
+        set(OPUS_TARGET PkgConfig::OPUS)
+    endif()
 endif()
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Widgets Network Sql Test LinguistTools)
@@ -77,6 +95,32 @@ else()
 endif()
 
 if(ENABLE_VOICE)
+    find_package(MLSPP QUIET)
+    if (NOT MLSPP_FOUND)
+        message(STATUS "mlspp not found, using subproject")
+        set(DISABLE_GREASE ON CACHE BOOL "" FORCE)
+        set(TESTING OFF CACHE BOOL "" FORCE)
+        set(MLS_CXX_NAMESPACE "mlspp" CACHE STRING "" FORCE)
+        set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
+        add_subdirectory(vendor/mlspp EXCLUDE_FROM_ALL)
+        if (NOT TARGET MLSPP::mlspp)
+            add_library(MLSPP::mlspp ALIAS mlspp)
+        endif ()
+        if (NOT TARGET MLSPP::hpke)
+            add_library(MLSPP::hpke ALIAS hpke)
+        endif ()
+        set(MLSPP_FOUND TRUE CACHE BOOL "" FORCE)
+        # Write a shim config so libdave's find_dependency(MLSPP) finds this
+        # instead of the broken build-tree config that add_subdirectory generates
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mlspp-shim/MLSPPConfig.cmake"
+            "set(MLSPP_FOUND TRUE)\n")
+        set(MLSPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/mlspp-shim" CACHE PATH "" FORCE)
+    else ()
+        message(STATUS "Found system mlspp")
+    endif ()
+
+    # Prevent find_package from finding mlspp's broken build-tree config via registry
+    set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
     # libdave (Discord Audio/Video E2E Encryption)
     set(TESTING OFF CACHE BOOL "" FORCE)
     set(PERSISTENT_KEYS OFF CACHE BOOL "" FORCE)
@@ -251,11 +295,14 @@ target_link_libraries(${PROJECT_NAME}
 )
 if(ENABLE_VOICE)
     target_link_libraries(${PROJECT_NAME} PRIVATE
-        unofficial-sodium::sodium
-        Opus::opus
+        ${SODIUM_TARGET}
+        ${OPUS_TARGET}
         libdave
     )
-    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/miniaudio")
+
+    target_include_directories(${PROJECT_NAME} PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/vendor/miniaudio"
+    )
 endif()
 if(TARGET Qt::ZlibPrivate)
     target_link_libraries(${PROJECT_NAME} PRIVATE Qt::ZlibPrivate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,12 @@ option(BUILD_TESTS "Build test targets" ON)
 option(ENABLE_VOICE "Build with voice/audio support" ON)
 option(ENABLE_RNNOISE "Build with RNNoise noise suppression (requires ENABLE_VOICE)" ON)
 option(ENABLE_RNNOISE_RTCD "Use RNNoise x86 runtime SIMD dispatch (SSE4.1/AVX2)" ON)
-
 if(BUILD_TESTS)
     enable_testing()
 endif()
 
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
-
 if(ENABLE_VOICE)
     if(USE_VCPKG)
         find_package(unofficial-sodium CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(CMAKE_AUTORCC ON)
 
 option(BUILD_TESTS "Build test targets" ON)
 option(ENABLE_VOICE "Build with voice/audio support" ON)
+option(ENABLE_RNNOISE "Build with RNNoise noise suppression (requires ENABLE_VOICE)" ON)
+option(ENABLE_RNNOISE_RTCD "Use RNNoise x86 runtime SIMD dispatch (SSE4.1/AVX2)" ON)
 
 if(BUILD_TESTS)
     enable_testing()
@@ -129,6 +131,9 @@ if(ENABLE_VOICE)
     add_subdirectory(vendor/libdave/cpp EXCLUDE_FROM_ALL)
 endif()
 
+# find or build rnnoise
+include(rnnoise.cmake)
+
 set(PROJECT_SOURCES
     resources.qrc
     src/main.cpp
@@ -226,6 +231,7 @@ if(ENABLE_VOICE)
         src/Core/AV/OpusDecoder.cpp
         src/Core/AV/JitterBuffer.cpp
         src/Core/AV/AudioMixer.cpp
+	src/Core/AV/NoiseSuppressor.cpp
     )
 endif()
 
@@ -302,6 +308,10 @@ if(ENABLE_VOICE)
     target_include_directories(${PROJECT_NAME} PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/vendor/miniaudio"
     )
+    if(ENABLE_RNNOISE)
+        target_link_libraries(${PROJECT_NAME} PRIVATE rnnoise)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE ACHERON_HAVE_RNNOISE)
+    endif()
 endif()
 if(TARGET Qt::ZlibPrivate)
     target_link_libraries(${PROJECT_NAME} PRIVATE Qt::ZlibPrivate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,15 @@ if(ENABLE_VOICE)
         find_package(unofficial-sodium CONFIG REQUIRED)
         find_package(Opus CONFIG REQUIRED)
 
-	set(SODIUM_TARGET unofficial-sodium::sodium)
+        set(SODIUM_TARGET unofficial-sodium::sodium)
         set(OPUS_TARGET Opus::opus)
     else()
         find_package(PkgConfig REQUIRED)
 
-	pkg_check_modules(SODIUM REQUIRED IMPORTED_TARGET libsodium)
-	pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
+        pkg_check_modules(SODIUM REQUIRED IMPORTED_TARGET libsodium)
+        pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
 
-	set(SODIUM_TARGET PkgConfig::SODIUM)
+        set(SODIUM_TARGET PkgConfig::SODIUM)
         set(OPUS_TARGET PkgConfig::OPUS)
     endif()
 endif()
@@ -95,28 +95,28 @@ endif()
 
 if(ENABLE_VOICE)
     find_package(MLSPP QUIET)
-    if (NOT MLSPP_FOUND)
+    if(NOT TARGET MLSPP::mlspp)
         message(STATUS "mlspp not found, using subproject")
         set(DISABLE_GREASE ON CACHE BOOL "" FORCE)
         set(TESTING OFF CACHE BOOL "" FORCE)
         set(MLS_CXX_NAMESPACE "mlspp" CACHE STRING "" FORCE)
         set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF CACHE BOOL "" FORCE)
         add_subdirectory(vendor/mlspp EXCLUDE_FROM_ALL)
-        if (NOT TARGET MLSPP::mlspp)
+        if(NOT TARGET MLSPP::mlspp)
             add_library(MLSPP::mlspp ALIAS mlspp)
-        endif ()
-        if (NOT TARGET MLSPP::hpke)
+        endif()
+        if(NOT TARGET MLSPP::hpke)
             add_library(MLSPP::hpke ALIAS hpke)
-        endif ()
+        endif()
         set(MLSPP_FOUND TRUE CACHE BOOL "" FORCE)
         # Write a shim config so libdave's find_dependency(MLSPP) finds this
         # instead of the broken build-tree config that add_subdirectory generates
         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mlspp-shim/MLSPPConfig.cmake"
             "set(MLSPP_FOUND TRUE)\n")
         set(MLSPP_DIR "${CMAKE_CURRENT_BINARY_DIR}/mlspp-shim" CACHE PATH "" FORCE)
-    else ()
+    else()
         message(STATUS "Found system mlspp")
-    endif ()
+    endif()
 
     # Prevent find_package from finding mlspp's broken build-tree config via registry
     set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
@@ -303,9 +303,7 @@ if(ENABLE_VOICE)
         libdave
     )
 
-    target_include_directories(${PROJECT_NAME} PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/vendor/miniaudio"
-    )
+    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/miniaudio")
     if(ENABLE_RNNOISE)
         target_link_libraries(${PROJECT_NAME} PRIVATE rnnoise)
         target_compile_definitions(${PROJECT_NAME} PRIVATE ACHERON_HAVE_RNNOISE)


### PR DESCRIPTION
Made mlspp a submodule and made vcpkg optional so system packages can be used. It succesfully builds and runs. The vcpkg usage can be toggled via -DUSE_VCPKG=ON/OFF.